### PR TITLE
adjusted mobile scale

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -19,7 +19,7 @@
     --cookie-spot-red-color: #DA723C;
     /* transforms */
     --original-scale: scale(0.6);
-    --mobile-scale: scale(0.35);
+    --mobile-scale: scale(0.3);
     --mouth-circle-rotation: rotate(10deg);
     /* positions */
     --mouth-circle-left-position: 16%;


### PR DESCRIPTION
Fixed issue #13. Investigated the bug. Only happens on bigger font-size because of rem scaling. So it is more of a feature then a bug ;). Siriously though can only be fixed when programming in px. But that is bad for accessebility.

For a beter result on mobile, changed the mobile scale.