### PR TITLE
fixed the issue by adding condition in if-statement

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -40,14 +40,15 @@ function onSnackTime(){
  * @param {*} event - default JS event property that is needed to read me data from
  * @returns void
  */
-mouth.onmouseenter = function(event){
-    if(!event.relatedTarget.classList.contains("cookie") && cookieIsDragged === false) return;
+mouth.onmouseover = function(event){
+    if(event.releatedTarget !== null && event.relatedTarget.classList.contains("cookie") && cookieIsDragged === false){
         mouth.classList.toggle("a-eat");
         event.relatedTarget.classList.add("cookie--eaten--1");
         music.play();   
         setTimeout(function(){
             mouth.classList.toggle("a-eat");
         },animationTime);
+    }
 }
 
 /**


### PR DESCRIPTION
The bug in issue #22  was created by hovering fast when a cookie was eaten. I don't really know what triggered the bug but a guess is that a related target could be set to something other than a cookie. It looks like it is fixed by changing onmouseleave to on mouseover with a extra condition to the if-statement, which also serves as a fallback so that there won't be an error in the console